### PR TITLE
fix e_key_code for linux

### DIFF
--- a/ogv1.h
+++ b/ogv1.h
@@ -1,7 +1,8 @@
 #ifndef OGV1_H
 # define OGV1_H
 
-#include "./minilibx_opengl_20191021/mlx.h"
+/* #include "./minilibx_opengl_20191021/mlx.h" */
+#include "./minilibx-linux/mlx.h"
 #include "libft/libft.h"
 #include "gnl/get_next_line.h"
 #include <stdio.h>
@@ -50,15 +51,29 @@ enum	e_color
 	BROWN	=	0x764B00,
 };
 
+/* mac用 */
+/* enum	e_key_code */
+/* { */
+/* 	KEY_W		= 13, */
+/* 	KEY_S		= 1, */
+/* 	KEY_A		= 0, */
+/* 	KEY_D		= 2, */
+/* 	KEY_ESC		= 53, */
+/* 	KEY_LEFT	= 123, */
+/* 	KEY_RIGHT	= 124 */
+/* }; */
+
+/* linux用 */
 enum	e_key_code
 {
-	KEY_W		= 13,
-	KEY_S		= 1,
-	KEY_A		= 0,
-	KEY_D		= 2,
-	KEY_ESC		= 53,
-	KEY_LEFT	= 123,
-	KEY_RIGHT	= 124
+	KEY_W		= 119,
+	KEY_S		= 115,
+	KEY_A		= 97,
+	KEY_D		= 100,
+	/* KEY_ESC		= 27, */
+	KEY_ESC		= 65307,
+	KEY_LEFT	= 65361,
+	KEY_RIGHT	= 65363
 };
 
 typedef	enum e_parse_kind


### PR DESCRIPTION
linuxのkeymapに合わせてe_key_codeを修正しました

`showkey -a`
にて確認。
ただし、KEY_ESC,KEY_LEFT,KEY_RIGHTは内部では16進数なので議論の余地があり