### PR TITLE
fix get_vartical_firstの引数ray_angleがintで受け取っていたのをdoubleに修正

### DIFF
--- a/includes/calc.h
+++ b/includes/calc.h
@@ -35,7 +35,7 @@ typedef struct s_inter
 
 double calc_distance(double ray_angle, t_player player, t_intersection res);
 double calc_offset(double ray_angle, enum e_axis axis, t_intersection inter, t_map map, t_mlx *mlx);
-int		get_vartical_first(t_mlx *mlx, int *pos_y, int ray_angle);
+int get_vartical_first(t_mlx *mlx, int *pos_y, double ray_angle);
 int		get_horizontal_first(t_mlx *mlx, int *pos_y, double ray_angle);
 void	display_vartical_grid_intersection(t_mlx *mlx, t_intersection pos, int color, double ray_angle);
 void	display_horizontal_grid_intersection(t_mlx *mlx, t_intersection pos, int color, double ray_angle);

--- a/srcs/calc_intersection.c
+++ b/srcs/calc_intersection.c
@@ -25,7 +25,7 @@ double calc_offset(double ray_angle, enum e_axis axis, t_intersection inter, t_m
 	}
 }
 
-int get_vartical_first(t_mlx *mlx, int *pos_y, int ray_angle)
+int get_vartical_first(t_mlx *mlx, int *pos_y, double ray_angle)
 {
 	t_map map = mlx->map;
 	t_player player = mlx->player;


### PR DESCRIPTION
rayがスカスカになっていた/右上の直角の壁をすり抜ける原因はこれでした。